### PR TITLE
Add config for Sigil MIDI tracks.

### DIFF
--- a/sigil-music.cfg
+++ b/sigil-music.cfg
@@ -1,0 +1,15 @@
+# Config file for Sigil high quality MIDI pack.
+
+# SHA1 hash                              = filename
+31e9932f8260b1e8ebd5e110af8749d46aa95365 = sigil-music/d_e5m1.flac
+7211fc6f2f48cf1f27022690da6ed9b6363cb671 = sigil-music/d_e5m2.flac
+f7fe0a11e9a5fe6aecdf6a36299df33dd201eaef = sigil-music/d_e5m3.flac
+fdcbb17ba408bc90af2bc295a6f6e51dd650d247 = sigil-music/d_e5m4.flac
+1d8a8dd6b374287b8848f2d65d4f6e0900b835e3 = sigil-music/d_e5m5.flac
+921f7ac3bcb97e44f2c48b1ae79310848587d47b = sigil-music/d_e5m6.flac
+e5b6631a1a657518371f61794cb7ff801ea57a68 = sigil-music/d_e5m7.flac
+f86a6143fa0d5e38a2e09e011428bc867e3fb9a8 = sigil-music/d_e5m8.flac
+f86a11a12f525210b973c52583841cea1fc8ec79 = sigil-music/d_e5m9.flac
+bfac802f3fbbf9008ba0e74bfae46e5c687becb3 = sigil-music/d_inter.flac
+b7f165797cd500b351612b73267313f1df20a41e = sigil-music/d_intro.flac
+


### PR DESCRIPTION
I've created a configuration file to support digital MIDI music packs for the Sigil episode of Ultimate Doom, **SIGIL_v1_21.WAD**. Considering this is the closest thing to the official fifth episode, I figured someone else might find it useful.

The config is its own separate file because of name collisions for `d_inter` and `d_intro`.

I would greatly appreciate any feedback.