### PR TITLE
Add config for Plutonia music tracks

### DIFF
--- a/plutonia-music.cfg
+++ b/plutonia-music.cfg
@@ -1,0 +1,40 @@
+# Config file for PLUTONIA high quality MIDI pack.
+
+# PLUTONIA.WAD's music is reused from Doom I+II, so it can reuse the files from the base games' music packs.
+
+# SHA1 hash                              = filename                   # MIDI filename
+b5e7dfb4efe9e688bf2ae6163c9d734e89e643b1 = doom1-music/d_e1m2.flac    # D_RUNNIN
+fda8fa73e4d30a6b961cd46fe6e013395e87a682 = doom1-music/d_e1m3.flac    # D_STALKS
+4450811b5a6748cfd83e3ea241222f6b88be33f9 = doom1-music/d_e1m6.flac    # D_COUNTD
+3805f9bf3f1702f7e7f5483a609d7d3c4daa2323 = doom1-music/d_e1m4.flac    # D_BETWEE
+62c631c2fdaa5ecd9a8d8f369917244f27128810 = doom1-music/d_e1m9.flac    # D_DOOM
+47d711a6fd32f5047879975027e5b152b52aa1dc = doom1-music/d_e1m8.flac    # D_THE_DA
+7702a6449585428e718558d8ecc387ef1a21d948 = doom1-music/d_e2m1.flac    # D_SHAWN
+1cb1810989cbfae2b29ba8d6d0f8f1175de45f03 = doom1-music/d_e2m2.flac    # D_DDTBLU
+ce3587ee503ffe707b2d8b690396114fdae6b411 = doom1-music/d_e3m3.flac    # D_IN_CIT
+73edb50d96b0ac03be34a6134b33e4c8f00fc486 = doom1-music/d_e1m7.flac    # D_DEAD
+3da3b1335560a92912e6d1eb542ba8c65dcb1d2c = doom1-music/d_bunny.flac   # D_STLKS2
+d746ea2aa16b3237422cb18ec66f26e12cb08d40 = doom1-music/d_e3m8.flac    # D_THEDA2
+b6c07bb249526b864208922d2d9ab655f4aade78 = doom1-music/d_e3m2.flac    # D_DOOM2
+90f06251a2a90bfaefd47a526b28264ea64f4f83 = doom1-music/d_e2m8.flac    # D_DDTBL2
+b26aad3caa420e9a2c76586cd59433b092fcba1c = doom1-music/d_e2m7.flac    # D_RUNNI2
+b2fb439f23c08c8e2577d262e5ed910a6a62c735 = doom1-music/d_e2m9.flac    # D_DEAD2
+99767e32769229897f7722848fb1ceccc2314d09 = doom1-music/d_e1m1.flac    # D_STLKS3
+73edb50d96b0ac03be34a6134b33e4c8f00fc486 = doom1-music/d_e1m7.flac    # D_ROMERO
+f546ed823b234fe391653029159de7b67a15dbd4 = doom1-music/d_e1m5.flac    # D_SHAWN2
+a55d400570ad255a576bc39d5b3f32a7f96a2728 = doom2-music/d_messag.flac  # D_MESSAG
+e632318629869811f7dca9b15d1912495ae6953b = doom2-music/d_read_m.flac  # D_COUNT2
+acb7ad85494d18235df83d3efb2c7c67df835a00 = doom2-music/d_ddtbl3.flac  # D_DDTBL3
+29d30c3fbd712016f2e574f8432b87b873d63187 = doom2-music/d_ampie.flac   # D_AMPIE
+8d32b2b7aa3b806474c1c237ef2b909478973c40 = doom2-music/d_theda.flac   # D_THEDA3
+bcfe9786afdcfb704afa563f6f387c2c2cb63e51 = doom2-music/d_adrian.flac  # D_ADRIAN
+a55d400570ad255a576bc39d5b3f32a7f96a2728 = doom2-music/d_messg2.flac  # D_MESSG2
+7702a6449585428e718558d8ecc387ef1a21d948 = doom1-music/d_e2m1.flac    # D_ROMER2
+1cb1810989cbfae2b29ba8d6d0f8f1175de45f03 = doom1-music/d_e2m2.flac    # D_TENSE
+99767e32769229897f7722848fb1ceccc2314d09 = doom1-music/d_e1m1.flac    # D_SHAWN3
+fca4086939a68ae4ed84c96e6bf0bd5621ddbe3d = doom1-music/d_victor.flac  # D_OPENIN
+47d711a6fd32f5047879975027e5b152b52aa1dc = doom1-music/d_e1m8.flac    # D_EVIL
+90f06251a2a90bfaefd47a526b28264ea64f4f83 = doom1-music/d_e2m8.flac    # D_ULTIMA
+e632318629869811f7dca9b15d1912495ae6953b = doom2-music/d_read_m.flac  # D_READ_M
+56f2363f01df38908c77cf4734f8dc3a3a820d7d = doom2-music/d_dm2ttl.flac  # D_DM2TTL
+71e58baf9e9dea4dd24ad8013c2f5a60134f117c = doom2-music/d_dm2int.flac  # D_DM2INT


### PR DESCRIPTION
Plutonia's tracks are reused from Doom I+II, so they can be pulled from the user's installation of music packs for Doom I and Doom II.